### PR TITLE
Created and Added files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore Godot editor and cache files
+.project_octopus/.godot/editor/*
+.project_octopus/.godot/uid_cache.bin


### PR DESCRIPTION
Solution to: Issue #69 

Many of our merges have conflicts that don't need to be there. Mostly from our IDE settings.
This should also stop pulling from changing our IDE settings (hopefully) 

The files added causing merging conflicts:
`
project_octopus/.godot/editor/create_recent.Node
project_octopus/.godot/editor/editor_layout.cfg
project_octopus/.godot/editor/filesystem_cache8
project_octopus/.godot/editor/filesystem_update4
project_octopus/.godot/editor/node_3d.tscn-editstate-14584830dbc22d3f76a596eed5f4948e.cfg
project_octopus/.godot/editor/project_metadata.cfg
project_octopus/.godot/editor/recent_dirs
project_octopus/.godot/editor/script_editor_cache.cfg
project_octopus/.godot/uid_cache.bin
`
Files added to .gitignore:
`
# Ignore Godot editor and cache files
.project_octopus/.godot/editor/*
.project_octopus/.godot/uid_cache.bin
`
 note: everything in the editor directory is being passed over by git
