### PR TITLE
fixed canvas layer formatting and menu blocking

### DIFF
--- a/project_octopus/node_3d.tscn
+++ b/project_octopus/node_3d.tscn
@@ -683,8 +683,8 @@ bus = &"Music"
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
-[node name="pause_menu" parent="CanvasLayer" instance=ExtResource("11_o04wj")]
-
 [node name="ScreenColorer" type="ColorRect" parent="CanvasLayer"]
 offset_right = 1152.0
 offset_bottom = 648.0
+
+[node name="pause_menu" parent="CanvasLayer" instance=ExtResource("11_o04wj")]


### PR DESCRIPTION
## Fixes
- The layer that was being used for the red flash when getting attacked was blocking the menu layer, so swapped them.

