### PR TITLE
Octo Spawning (for real)

### DIFF
--- a/project_octopus/day_and_night.gd
+++ b/project_octopus/day_and_night.gd
@@ -1,32 +1,35 @@
 extends Node3D
 
-@export var day_length: float = 60.0  # Duration of the day in seconds
-@export var night_length: float = 60.0  # Duration of the night in seconds
+@export var day_length: float = 150.0  # Duration of the day in seconds
+@export var night_length: float = 150.0  # Duration of the night in seconds
 @export var world_environment: WorldEnvironment
 @export var day_text: Label
 
+var overall_progress = 0.5
+
 var time_passed: float = 0.0
-var is_day: bool = true
+var is_day: bool = false
 var current_day: int = 1
 
-func _ready() -> void:
-	time_passed += day_length / 2
 
 func _process(delta):
-	day_text.text = "Day " + str(current_day)
 	time_passed += delta
 	
 	var cycle_duration = day_length if is_day else night_length
 	var progress = time_passed / cycle_duration
+	overall_progress = (time_passed + (day_length * int(!is_day))) / (day_length + night_length)
+	
+	var hour = float(int(overall_progress * 24 * 10)) / 10 #round to first decimal place
+	day_text.text = "Day " + str(current_day) + " Hour " + str(hour)
 	
 	if world_environment:
 		var env = world_environment.environment
 		if env:
 			# Interpolate brightness for smooth transition
 			if is_day:
-				env.adjustment_brightness = lerp(0.1, 1.0, progress)  # Night to Day
+				env.adjustment_brightness = lerp(0.25, 1.0, progress)  # Night to Day
 			else:
-				env.adjustment_brightness = lerp(1.0, 0.1, progress)  # Day to Night
+				env.adjustment_brightness = lerp(1.0, 0.25, progress)  # Day to Night
 				
 	
 	# switches what cycle to use

--- a/project_octopus/node_3d.tscn
+++ b/project_octopus/node_3d.tscn
@@ -2,13 +2,13 @@
 
 [ext_resource type="Script" path="res://worldbuilder.gd" id="1_bydk5"]
 [ext_resource type="Script" path="res://player.gd" id="1_d34xq"]
+[ext_resource type="Script" path="res://spawner.gd" id="1_yc5s2"]
 [ext_resource type="Texture2D" uid="uid://dbqsl5ndmwj7b" path="res://sprite_anim/Ryan-Sheet.png" id="4_auwos"]
 [ext_resource type="AnimationLibrary" uid="uid://sbg0xefx5154" path="res://sprite_anim/player_animation_suite.res" id="4_s4vnr"]
 [ext_resource type="Texture2D" uid="uid://srv1mn78bjml" path="res://Sprite-0001-Sheet.png" id="5_36hur"]
 [ext_resource type="Script" path="res://camera_3d.gd" id="6_0k1nh"]
 [ext_resource type="Script" path="res://day_and_night.gd" id="6_3wk7r"]
 [ext_resource type="Texture2D" uid="uid://cwldstqsr6pf" path="res://sprite_anim/RANGED_Braton.png" id="6_chvu4"]
-[ext_resource type="PackedScene" uid="uid://cf1crfbecqrp0" path="res://octopus.tscn" id="7_b4y4o"]
 [ext_resource type="Texture2D" uid="uid://2l1o23jp8jle" path="res://sprite_anim/RANGED_Flamethrower.png" id="7_udelx"]
 [ext_resource type="Texture2D" uid="uid://bx3ccew8hk3md" path="res://sprite_anim/TEMP_extra_idles.png" id="7_wftrk"]
 [ext_resource type="AudioStream" uid="uid://cyrvm4snkn64l" path="res://game_sfx/walking_sound_short.mp3" id="8_4rnoe"]
@@ -497,6 +497,7 @@ material = SubResource("StandardMaterial3D_otyry")
 size = Vector3(0.1, 0.1, 0.1)
 
 [node name="Node3D2" type="Node3D"]
+script = ExtResource("1_yc5s2")
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_opreq")
@@ -600,12 +601,6 @@ sky_mode = 1
 script = ExtResource("6_3wk7r")
 world_environment = NodePath("../WorldEnvironment")
 day_text = NodePath("../Control/Day Text")
-
-[node name="Octopus" parent="." instance=ExtResource("7_b4y4o")]
-transform = Transform3D(-1.31134e-07, 0, 3, 0, 3, 0, -3, 0, -1.31134e-07, -5.98473e-08, 362.935, -5.94867)
-max_health = 100
-damage = 10
-speed = 2.0
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3

--- a/project_octopus/octopus.tscn
+++ b/project_octopus/octopus.tscn
@@ -85,7 +85,7 @@ material = SubResource("StandardMaterial3D_3qj6u")
 size = Vector3(0.25, 0.25, 0.25)
 
 [node name="Octopus" type="CharacterBody3D"]
-transform = Transform3D(-4.37114e-07, 0, 10, 0, 10, 0, -10, 0, -4.37114e-07, 0, 0, 0)
+transform = Transform3D(-1.31134e-07, 0, 3, 0, 3, 0, -3, 0, -1.31134e-07, 0, 0, 0)
 collision_layer = 3
 collision_mask = 3
 script = ExtResource("1_3w4aa")

--- a/project_octopus/spawner.gd
+++ b/project_octopus/spawner.gd
@@ -1,0 +1,44 @@
+extends Node3D
+
+@onready var WORLD_NODE = get_node("WorldEnvironment")
+@onready var TIME_NODE = get_node("Day and night")
+var mob = preload("res://octopus.tscn")
+@onready var rand=RandomNumberGenerator.new()
+var live_octos = []
+var waiting_octos = 2
+
+@export var MIN_TIME_TO_SPAWN = 0.5
+@export var MAX_TIME_TO_SPAWN = 15
+
+const MAX_ENEMIES = 20
+
+func _ready():
+	randomize()
+	while(true):		
+		# Spawn an octo. If there are too many, hold them and spawn them as soon as possible.
+		waiting_octos += 1
+		for x in range(waiting_octos):
+			if len(live_octos) < MAX_ENEMIES:
+				spawn()
+				waiting_octos -= 1
+			else:
+				break
+		
+		# Sin function with a peak at 0.5 (half of the day, where the game starts) and a min at 1 and 0, minimum MIN_TIME, maximum MAX_TIME
+		var time_to_next = ((MAX_TIME_TO_SPAWN + MIN_TIME_TO_SPAWN) / 2) - (sin(2 * PI * (TIME_NODE.overall_progress + 0.25)) * ((MAX_TIME_TO_SPAWN - MIN_TIME_TO_SPAWN) / 2))
+		#print(TIME_NODE.overall_progress, ", ", time_to_next)
+		await get_tree().create_timer(time_to_next).timeout
+	
+func spawn():
+	var angle = deg_to_rad(rand.randi_range(0,360))
+	var xLoc = cos(angle) * (WORLD_NODE.MAP_RAD - 2)
+	var yLoc = sin(angle) * (WORLD_NODE.MAP_RAD - 2)
+	print("SPAWN " + str(xLoc) + ", " + str(yLoc))
+	var m = mob.instantiate()
+	add_child(m)
+	live_octos.append(m)
+	m.octoTracker = self
+	m.global_position = Vector3i(xLoc,220,yLoc)
+	m.speed = 2
+	m.max_health = 100
+	m.damage = 25

--- a/project_octopus/weapon.tscn
+++ b/project_octopus/weapon.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://cgolw2bygh83w"]
+
+[ext_resource type="Script" path="res://weapon.gd" id="1_m3p6n"]
+[ext_resource type="Texture2D" uid="uid://du8eqyvw7rfdc" path="res://sprite_anim/MELEE_sword.png" id="2_ohox4"]
+
+[node name="Weapon" type="Node3D"]
+script = ExtResource("1_m3p6n")
+damage = 15.0
+range = 5.0
+projectileSpeed = 30.0
+fireRate = 0.5
+
+[node name="Sprite3D" type="Sprite3D" parent="."]
+transform = Transform3D(0.999655, 0, -0.0262642, 0, 1, 0, 0.0262642, 0, 0.999655, 0, 0, 0)
+centered = false
+offset = Vector2(-10, 0)
+pixel_size = 0.0225
+texture_filter = 0
+texture = ExtResource("2_ohox4")


### PR DESCRIPTION
## SUMMARY
Octopi spawning


## CHANGES
- octopi spawn in random points at the edge of the map
- capped at 20 enemies at once, but more queue up for fast replacement to give some illusion of a higher cap
- spawn times vary across the day
- added current hour to the HUD for primitive scoring and keeping track of time
- slightly brightened the darkest the game gets so the player can actually see what they're doing

## WHY
Making this more of a game rather than just a test


## HOW TO TEST
Walk around and wait for one to come up to you, or walk to the edges of the map and hope to see one spawn


## NOT DONE
Might have messed up the day/night timing? Printed logs seem to be slightly off from the hour shown in game but this might just be the print statements being time-consuming. It slowly gets more off over time though ...
